### PR TITLE
Improvements

### DIFF
--- a/guides/getting-started/pom.xml
+++ b/guides/getting-started/pom.xml
@@ -15,7 +15,7 @@
         <!-- compile -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
         <!-- test -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,13 @@
     <name>quoss :: quarkus :: quarkus-projects</name>
     <description>Collection of Quarkus only projects (not Camel Quarkus).</description>
     <properties>
+        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+        <maven.surefire.plugin.version>3.3.0</maven.surefire.plugin.version>
+
+        <maven.compiler.proc>full</maven.compiler.proc>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <quarkus.version>3.12.0</quarkus.version>
     </properties>
     <modules>
@@ -39,6 +44,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven.compiler.plugin.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>io.quarkus.platform</groupId>
                     <artifactId>quarkus-maven-plugin</artifactId>
                     <version>${quarkus.version}</version>
@@ -61,6 +71,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven.surefire.plugin.version}</version>
                     <configuration>
                         <systemPropertyVariables>
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -70,6 +81,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven.surefire.plugin.version}</version>
                     <executions>
                         <execution>
                             <goals>

--- a/quarkus-data-source/README.md
+++ b/quarkus-data-source/README.md
@@ -38,7 +38,7 @@ So when calling ...
 2024-06-29 22:11:25,925 INFO  [de.quo.qua.dat.sou.App] (main) Drop customer table: [{UPDATE_COUNT=0}]
 ```
 
-I consider the behaviour of the agroal pool a bug, as the result set is closed implicitely when the statement is closed.
+I consider the behaviour of the agroal pool a bug, as the result set is closed implicitly when the statement is closed.
 
 But on the other hand leads the explicitly closing of the result set to clearer coding maybe, though some boilerplate
 code is needed. Just answer this for yourself.

--- a/quarkus-data-source/src/main/java/de/quoss/quarkus/data/source/App.java
+++ b/quarkus-data-source/src/main/java/de/quoss/quarkus/data/source/App.java
@@ -1,6 +1,7 @@
 package de.quoss.quarkus.data.source;
 
 import io.quarkus.logging.Log;
+import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
 import java.sql.Connection;
@@ -13,6 +14,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.sql.DataSource;
 
 @QuarkusMain
@@ -23,12 +25,17 @@ public class App implements QuarkusApplication {
     public App (final DataSource ds) {
         this.ds = ds;
     }
+
+    public static void main(String... args) {
+        Quarkus.run(App.class, args);
+    }
     
     @Override
-    public int run(String[] args) {
+    public int run(String... args) {
         Log.info("Start");
-        switch (args[0]) {
-            case "agroal-result-set-leaked" -> agroalResultSetLeaked();
+        final String arg = Optional.ofNullable(args.length == 0 ? "" : args[0]).orElse("");
+        switch (arg) {
+            case "agroal-result-set-leaked", "" -> agroalResultSetLeaked();
             default -> throw new IllegalStateException("Unknown funktion: " + args[0]);
         }
         Log.info("End");

--- a/quarkus-data-source/src/main/java/de/quoss/quarkus/data/source/App.java
+++ b/quarkus-data-source/src/main/java/de/quoss/quarkus/data/source/App.java
@@ -36,7 +36,7 @@ public class App implements QuarkusApplication {
         final String arg = Optional.ofNullable(args.length == 0 ? "" : args[0]).orElse("");
         switch (arg) {
             case "agroal-result-set-leaked", "" -> agroalResultSetLeaked();
-            default -> throw new IllegalStateException("Unknown funktion: " + args[0]);
+            default -> throw new IllegalStateException("Unknown function: " + args[0]);
         }
         Log.info("End");
         return 0;


### PR DESCRIPTION
- Add main method, make program executable without parameters
- Fix typos
- Change `quarkus-resteasy-reactive` to `quarkus-rest`
- Fix compiler warnings
  - Manage versions for `maven-compiler-plugin`, `maven-surefire-plugin` and `maven-failsafe` plugin explicitly
  - Set `maven.compiler.proc=full`
- Remove code duplication
- Make the results unmodifiable earlier